### PR TITLE
Move test.c out of sketch dir

### DIFF
--- a/Arduino/Makefile
+++ b/Arduino/Makefile
@@ -5,18 +5,20 @@ CFLAGS = -Wall
 LFLAGS = -lm
 OBJS = *.o
 CFILES = LLAMAS/*.c
+TESTFILE = test.c
 HFILES = LLAMAS/*.h
-MAIN = test
+TESTMAIN = test
 
 
 all: $(CFILES) $(HFILES)
 	$(CC) $(CFLAGS) -c $(CFILES)	
+	$(CC) $(CFLAGS) -c $(TESTFILE)	
 	@echo "Compilation complete"
 	
 
 test: 
 	make all
-	$(CC) $(CFLAGS) $(LFLAGS) -o $(MAIN) $(OBJS)
+	$(CC) $(CFLAGS) $(LFLAGS) -o $(TESTMAIN) $(OBJS)
 	@echo "Linking complete!"
 	@echo "Executing test!"
 	./test

--- a/Arduino/test.c
+++ b/Arduino/test.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 //#include "LLAMAS/faultManagement.h"
 //#include "LLAMAS/rwInjection.h"
-#include "recovery.h"
-#include "rwInjection.h"
+#include "LLAMAS/recovery.h"
+#include "LLAMAS/rwInjection.h"
 
 //TODO: recovery seems to be doing some really trivial shit. Let's revisit this
 // and see if it's really necessary


### PR DESCRIPTION
This moves test.c out of the sketch directory. This is desirable since test.c is an extraneous file which is unnecessary for the running of the code on the MCU, and we don't want to bloat the software on the MCU unnecessarily