### PR TITLE
Remove -Wall from Makefile

### DIFF
--- a/Arduino/Makefile
+++ b/Arduino/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all
 
 CC = gcc
-CFLAGS = -Wall
+CFLAGS = #-Wall
 LFLAGS = -lm
 OBJS = *.o
 CFILES = LLAMAS/*.c


### PR DESCRIPTION
It makes the output super noisy. We should add another make target to
include -Wall, such as verbose-test, or something like that