### PR TITLE
Integrate fault injection

### DIFF
--- a/libraries/fault_sdk/faultManagement.c
+++ b/libraries/fault_sdk/faultManagement.c
@@ -48,7 +48,7 @@ void manageFaultAlreadyDetected(FmState *fmState) {
 	// fmState->cmdToRecover will be 1 when the system is commanded to initiate recovery
 	// from the GSU. The setting of this bit is handled by the communication
 	// handlers
-	if (fmState->cmdToRecover)
+	if (!fmState->cmdToRecover)
 		return;
 
 	fmState->cmdToRecover = 0;

--- a/libraries/fault_sdk/faultManagement.h
+++ b/libraries/fault_sdk/faultManagement.h
@@ -18,15 +18,12 @@ extern "C" {
 void faultManagement(FmState *fmState, float *angularAccel, float *commandedTorque,
 		uint16_t dataLength, float MOI);
 
-// void faultManagement(uint8_t *isFaulted, uint8_t *isRecovering, uint8_t *faultType, 
-// 		uint8_t *cmdToRecover, uint8_t *faultTimerActive, uint8_t *isPrimaryRWActive, 
-// 		uint8_t *isPrimaryFSActive, float *angularAccel, float *commandedTorque,
-// 		uint16_t dataLength, float MOI);
-
 void manageNewFaultDetected(FmState *fmState);
 
 void manageFaultAlreadyDetected(FmState *fmState);
 unsigned char checkThreshold();
+
+uint8_t faultCheckRW(FmState *fmState, float *angularAccel, float *commandedTorque, uint16_t length, float MOI);
 
 unsigned char faultCheck();
 

--- a/libraries/fault_sdk/rwInjection.c
+++ b/libraries/fault_sdk/rwInjection.c
@@ -5,6 +5,8 @@
  * Author(s) : Pol Sieira & Corwin Sheahan
  */ 
 
+#include <fm_util.h>
+#include <inttypes.h>
 #include "rwInjection.h"
 
 
@@ -24,11 +26,9 @@ float calcInducedFriction(float omega, float p1, float p2) {
 // returns an injected torque value:
 // Variables [All units are SI units]:
 //	-isPrimaryRWactive: Should be 1 if primary reaction wheel is active, 0 otherwise
-float injectRWFault(unsigned char isPrimaryRWactive, unsigned char cmdToFaultRW, float tau_c, 
-		float omega, float p1, float p2, float delta_omega) {
-
+float injectRWFault(FmState *fmState, float tau_c, float omega, float p1, float p2, float delta_omega) {
 	float tau_hat_c, tau_hat_f;
-	if (isPrimaryRWactive && cmdToFaultRW) {
+	if (fmState->activeRW && fmState->cmdToFaultRW) {
 		if (omega < delta_omega && omega > -delta_omega) {
 		  // If the reaction wheel speed is close to 0, then we actually want to just 
 		  // turn off the commanded torque. The inclusion of friction could force the

--- a/libraries/fault_sdk/rwInjection.c
+++ b/libraries/fault_sdk/rwInjection.c
@@ -19,7 +19,11 @@
 //		of reaction wheel friction
 //	-I: Moment of inertia of reaction wheel
 float calcInducedFriction(float omega, float p1, float p2) {
-	float induced = p1*omega + p2*5;
+	float induced;
+	if (omega < 0)
+		induced = p1*omega - p2*5;
+	if (omega > 0)
+		induced = p1*omega + p2*5;
 	return induced; 
 }
 
@@ -34,7 +38,7 @@ float injectRWFault(FmState *fmState, float tau_c, float omega, float p1, float 
 		  // turn off the commanded torque. The inclusion of friction could force the
 		  // augmented friction to spin the wheel past 0 and in the opposite direction,
 		  // which is impossible for natural friction to do.
-		  tau_hat_c = 0;  
+		  tau_hat_c = 0.05*tau_c;  
 		} else {
 			tau_hat_f = calcInducedFriction(omega, p1, p2); 
 			// The commanded torque should be decreased by the 'induced' friction, which

--- a/libraries/fault_sdk/rwInjection.c
+++ b/libraries/fault_sdk/rwInjection.c
@@ -28,7 +28,7 @@ float calcInducedFriction(float omega, float p1, float p2) {
 //	-isPrimaryRWactive: Should be 1 if primary reaction wheel is active, 0 otherwise
 float injectRWFault(FmState *fmState, float tau_c, float omega, float p1, float p2, float delta_omega) {
 	float tau_hat_c, tau_hat_f;
-	if (fmState->activeRW && fmState->cmdToFaultRW) {
+	if (fmState->activeRW == 1 && fmState->cmdToFaultRW) {
 		if (omega < delta_omega && omega > -delta_omega) {
 		  // If the reaction wheel speed is close to 0, then we actually want to just 
 		  // turn off the commanded torque. The inclusion of friction could force the

--- a/libraries/fault_sdk/rwInjection.h
+++ b/libraries/fault_sdk/rwInjection.h
@@ -12,10 +12,11 @@
 extern "C" {
 #endif
 
+#include <fm_util.h>
+
 float calcInducedFriction(float omega, float p1, float p2);
 
-float injectRWFault(unsigned char isPrimaryRWactive, unsigned char cmdToFaultRW, float tau_c, 
-		float omega, float p1, float p2, float delta_omega);
+float injectRWFault(FmState *fmState, float tau_c, float omega, float p1, float p2, float delta_omega);
 
 #ifdef __cplusplus
 }

--- a/libraries/fmUtil/fm_util.c
+++ b/libraries/fmUtil/fm_util.c
@@ -8,7 +8,8 @@ void initializeFaultState(FmState *fmState) {
   fmState->isRecovering = 0;
   fmState->faultType = 0;
   fmState->cmdToRecover = 0;
-  fmState->faultTimerActive = 2;
-  fmState->isPrimaryRWActive = 0;
-  fmState->isPrimaryFSActive = 1;
+  fmState->faultTimerActive = 0;
+  fmState->activeRW = 1;
+  fmState->activeFS = 1;
+  fmState->faultTimerStart = 0;
 }

--- a/libraries/fmUtil/fm_util.h
+++ b/libraries/fmUtil/fm_util.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include <inttypes.h>
 
 typedef struct {
 	uint8_t isFaulted;
@@ -11,8 +12,9 @@ typedef struct {
 	uint8_t faultType;
 	uint8_t cmdToRecover;
 	uint8_t faultTimerActive;
-	uint8_t isPrimaryRWActive;
-	uint8_t isPrimaryFSActive;
+	uint8_t activeRW; //Reaction wheels: 0 == both off, 1 == primary is on, 2 == secondary is on
+	uint8_t activeFS; //Fine sensors: 0 == both off, 1 == primary is on, 2 == secondary is on
+    unsigned long faultTimerStart;
 } FmState;
 
 void initializeFaultState(FmState *fmState);

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -70,6 +70,7 @@ static int i = 0;
 int k;
 char buf[32];
 uint16_t blocks;     
+
 double const convertPixToDegCoarse = 0.2748;
 double const convertPixToDegFine = 0.0522;
 double const centerOffsetDegFine = 160*convertPixToDegFine;
@@ -129,8 +130,8 @@ void loop()
   mockTimeStamp += 0.01;
 
   digitalWrite(46,LOW);
-  
-  //blocks = pixy.getBlocks();// NOTE: TO run on board which is not pixy enabled, comment this line out
+
+  blocks = pixy.getBlocks();// NOTE: TO run on board which is not pixy enabled, comment this line out
 
   if (blocks)
   {

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -29,7 +29,7 @@ double Setpoint, deltaThetaRad, commandedTorque_mNm;
 double const Kp=0.4193213777, Ki=0.003150323227, Kd=12.61957147, N=0.155;
 PID myPID(&deltaThetaRad, &commandedTorque_mNm, &Setpoint, Kp, Ki, Kd, N, DIRECT);
 
-FmState base = {.isFaulted = 0};
+FmState base;
 FmState *fmState = &base;
 
 void setup() 
@@ -76,15 +76,6 @@ double const convertPixToDegFine = 0.0522;
 double const centerOffsetDegFine = 160*convertPixToDegFine;
 double const convertDegToRad = 3.1415926535897932384626433832795/180;
 
-// Fault status "bits" as uint8_t since c doesn't support bools (c++ does, but not c)
-uint8_t isPrimaryRWActive; 
-uint8_t isPrimaryFSActive;
-uint8_t cmdToFaultRW; // 0 if no command to fault, otherwise 1. Should be set only by comms
-uint8_t isFaulted;
-uint8_t isRecovering;
-uint8_t faultType; // 0 if no fault, 1 if fine sensor fault, 2 if coarse sensor fault
-uint8_t cmdToRecover;
-uint8_t faultTimerActive;
 float rwSpeedRad; 
 float const p1 = 10.0; // TODO: p1 and p2 need to be set via data from Dalton. These are just placeholders
 float const p2 = 10.0; 

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -77,15 +77,15 @@ double const centerOffsetDegFine = 160*convertPixToDegFine;
 double const convertDegToRad = 3.1415926535897932384626433832795/180;
 
 float rwSpeedRad; 
-float const p1 = 10.0; // TODO: p1 and p2 need to be set via data from Dalton. These are just placeholders
-float const p2 = 10.0; 
+float const p1 = 1; //TODO: Determine these better
+float const p2 = 0.1303; // mNm, coloumb friction
+float MOI = 1; //MOI of RW, stubbed out for now
 float delta_omega; // small delta near zero where we set torque to zero to simulate friction. TODO: Tune this value
 uint16_t const lengthOfHistory = 1000;
 // currentIndex points to the most recent data point. The last 100 data points are accumulated "behind"
 // this index. For example, if the currentIndex is 55, the order (in terms of recency) of the stored indicies
 // is 55....0...99...56. I.e. the most recently stored index is 55 (just stored), and the oldest stored index is 56.
 uint16_t currentIndex = 0;
-float MOI = 1; //MOI of RW, stubbed out for now
 
 //TODO: Determine units and ideal length for these. 
 float commandedTorqueHistory[lengthOfHistory];
@@ -114,10 +114,9 @@ void loop()
   storeTorqueAndIncrementIndex(commandedTorqueHistory, &currentIndex, mockCommandTorque, lengthOfHistory);
 
   // TODO: Actually get these values and replace mocks in function calls. commandedTorque will come from 
-  // control law. rwSpeed comes from encoder on RW, timeStamp comes from ???
+  // control law. rwSpeed comes from encoder on RW
   mockCommandTorque += 0.4;
   mockRWSpeed += 0.1;
-  mockTimeStamp += 0.01;
 
   digitalWrite(46,LOW);
 
@@ -135,9 +134,9 @@ void loop()
     // call to Compute assigns output to variable commandedTorque_mNm via pointers
     myPID.Compute(); 
 
+
     // TODO: Test injection strength and tune for delta_omega
-    commandedTorque_mNm = injectRWFault(isPrimaryRWActive, cmdToFaultRW, commandedTorque_mNm, 
-       rwSpeedRad, p1, p2, delta_omega);
+    commandedTorque_mNm = injectRWFault(fmState, commandedTorque_mNm, rwSpeedRad, p1, p2, delta_omega);
 
     pwm_duty = (commandedTorque_mNm*15*mNm_to_mA*mA_to_duty + pwmOffset)*duty_to_bin;
 

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -97,13 +97,12 @@ float orderedTimeStampHistory[lengthOfHistory];
 float angularAccel[lengthOfHistory-1];
 
 float mockRWSpeed = 0.0;
-float mockTimeStamp = 0.0;
 float mockCommandTorque = 0.4;
 
 void loop() 
 {
   // Log RW speed.
-  storeRWSpeed(reactionWheelSpeedHistory, timeStampHistory, currentIndex, mockRWSpeed, mockTimeStamp);
+  storeRWSpeed(reactionWheelSpeedHistory, timeStampHistory, currentIndex, mockRWSpeed, millis());
 
   // Stores ordered lists of last n = `lengthOfHistory` data points, with most recent being at index 0
   getOrderedHistory(reactionWheelSpeedHistory, orderedRWSpeedHistory, lengthOfHistory, currentIndex);

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -137,7 +137,7 @@ void loop()
 
     // TODO: Test injection strength and tune for delta_omega
     commandedTorque_mNm = injectRWFault(isPrimaryRWActive, cmdToFaultRW, commandedTorque_mNm, 
-      rwSpeedRad, p1, p2, delta_omega);
+       rwSpeedRad, p1, p2, delta_omega);
 
     pwm_duty = (commandedTorque_mNm*15*mNm_to_mA*mA_to_duty + pwmOffset)*duty_to_bin;
 


### PR DESCRIPTION
This integrates fault injection algorithm into the mocksat ADCS control loop. The injection works (mostly) as expected, and noticeably deteriorates the tracking quality. There will need to be some more work to tune this as time allows, but this should be enough to meet our requirement for fault injection of the reaction wheel. 

This also gets the reaction wheel feedback working properly

Also, our requirement for fault injection into the fine sensor was completed via #21 

FYI @daan3757 @posi7790 @Kele5448 @Benjamin-Hutchinson 