### PR TITLE
Create fi_util library

### DIFF
--- a/libraries/fault_sdk/fsInjection.c
+++ b/libraries/fault_sdk/fsInjection.c
@@ -7,14 +7,14 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <fm_util.h>
+#include <fi_util.h>
 #include <inttypes.h>
 #include "fsInjection.h"
 
 
-void fsInjection(double *deltaTheta, FmState *fmState)
+void fsInjection(double *deltaTheta, FiState *fiState)
 {   
-	if (fmState->cmdToFaultFS){
-		*deltaTheta += fmState->fsBias;
+	if (fiState->cmdToFaultFS){
+		*deltaTheta += fiState->fsBias;
 	}
 }

--- a/libraries/fault_sdk/fsInjection.h
+++ b/libraries/fault_sdk/fsInjection.h
@@ -12,9 +12,9 @@
 extern "C" {
 #endif
 
-#include <fm_util.h>
+#include <fi_util.h>
 
-void fsInjection(double *deltaTheta, FmState *fmState);
+void fsInjection(double *deltaTheta, FiState *fiState);
 
 #ifdef __cplusplus
 }

--- a/libraries/fiUtil/fi_util.c
+++ b/libraries/fiUtil/fi_util.c
@@ -7,5 +7,4 @@ void initializeFaultInjectState(FiState *fiState) {
   fiState->fsBias = 10;
   fiState->cmdToFaultRW = 0;
   fiState->cmdToFaultFS = 0;
-
 }

--- a/libraries/fiUtil/fi_util.c
+++ b/libraries/fiUtil/fi_util.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include "fi_util.h"
+
+void initializeFaultInjectState(FiState *fiState) {
+  fiState->fsBias = 10;
+  fiState->cmdToFaultRW = 0;
+  fiState->cmdToFaultFS = 0;
+
+}

--- a/libraries/fiUtil/fi_util.h
+++ b/libraries/fiUtil/fi_util.h
@@ -9,7 +9,7 @@ extern "C" {
 
 typedef struct {
 	float fsBias;
-    uint8_t cmdToFaultRW;
+	uint8_t cmdToFaultRW;
 	uint8_t cmdToFaultFS;
 } FiState;
 

--- a/libraries/fiUtil/fi_util.h
+++ b/libraries/fiUtil/fi_util.h
@@ -1,0 +1,21 @@
+#ifndef FI_UTIL_H_
+#define FI_UTIL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+
+typedef struct {
+	float fsBias;
+    uint8_t cmdToFaultRW;
+	uint8_t cmdToFaultFS;
+} FiState;
+
+void initializeFaultInjectState(FiState *fiState);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/libraries/fmUtil/fm_util.c
+++ b/libraries/fmUtil/fm_util.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include "fm_util.h"
 
-void initializeFaultState(FmState *fmState) {
+void initializeFaultManagementState(FmState *fmState) {
   fmState->isFaulted = 0;
   fmState->isRecovering = 0;
   fmState->faultType = 0;
@@ -11,7 +11,4 @@ void initializeFaultState(FmState *fmState) {
   fmState->faultTimerActive = 2;
   fmState->isPrimaryRWActive = 0;
   fmState->isPrimaryFSActive = 1;
-  fmState->cmdToFaultRW = 0;
-  fmState->cmdToFaultFS = 0;
-  fmState->fsBias = 10;
 }

--- a/libraries/fmUtil/fm_util.c
+++ b/libraries/fmUtil/fm_util.c
@@ -10,5 +10,5 @@ void initializeFaultManagementState(FmState *fmState) {
   fmState->cmdToRecover = 0;
   fmState->faultTimerActive = 2;
   fmState->isPrimaryRWActive = 0;
-  fmState->isPrimaryFSActive = 1;
+  fmState->isPrimaryFSActive = 0;
 }

--- a/libraries/fmUtil/fm_util.h
+++ b/libraries/fmUtil/fm_util.h
@@ -15,12 +15,9 @@ typedef struct {
 	uint8_t faultTimerActive;
 	uint8_t isPrimaryRWActive;
 	uint8_t isPrimaryFSActive;
-	uint8_t cmdToFaultRW;
-	uint8_t cmdToFaultFS;
-	float fsBias;
 } FmState;
 
-void initializeFaultState(FmState *fmState);
+void initializeFaultManagementState(FmState *fmState);
 
 #ifdef __cplusplus
 }

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -4,6 +4,7 @@ Servo myservo;
 #include <faultManagement.h>
 #include <rwInjection.h>
 #include <fm_util.h>
+#include <fi_util.h>
 #include <data_util.h>
 #include <SPI.h>  
 #include <Pixy.h>
@@ -29,8 +30,11 @@ double Setpoint, deltaThetaRad, commandedTorque_mNm;
 double const Kp=0.4193213777, Ki=0.003150323227, Kd=12.61957147, N=0.155;
 PID myPID(&deltaThetaRad, &commandedTorque_mNm, &Setpoint, Kp, Ki, Kd, N, DIRECT);
 
-FmState base = {.isFaulted = 0};
-FmState *fmState = &base;
+//Allocate for fm/fi state variables
+FmState fmBase;
+FmState *fmState = &fmBase;
+FiState fiBase;
+FiState *fiState = &fiBase;
 
 void setup() 
 { 
@@ -55,7 +59,9 @@ void setup()
   //Enable Cycle
   digitalWrite(27,HIGH);
 
-  initializeFaultState(fmState);
+
+  initializeFaultManagementState(fmState);
+  initializeFaultInjectState(fiState);
 } 
 
 //conversions for torques to PWM bins
@@ -71,6 +77,7 @@ int k;
 char buf[32];
 uint16_t blocks;     
 
+//conversions for pixy
 double const convertPixToDegCoarse = 0.2748;
 double const convertPixToDegFine = 0.0522;
 double const centerOffsetDegFine = 160*convertPixToDegFine;
@@ -128,7 +135,7 @@ void loop()
   if (blocks)
   {
     deltaThetaRadFine1 = ((pixy.blocks[0].x)*convertPixToDegFine - centerOffsetDegFine)*convertDegToRad;
-    fsInjection(&deltaThetaRadFine1, fmState);
+    fsInjection(&deltaThetaRadFine1, fiState);
     deltaThetaRad = deltaThetaRadFine1;
     
     faultManagement(fmState, angularAccel, orderedCommandedTorqueHistory,


### PR DESCRIPTION
This creates the fi_util library, abstracting away fault injection items/state from fault injection items/state. This is important because we want the two pieces to move independently of each other and be agnostic to each other's existence. 