### PR TITLE
Make near-zero friction inducing logic better

### DIFF
--- a/libraries/fault_sdk/rwInjection.c
+++ b/libraries/fault_sdk/rwInjection.c
@@ -34,11 +34,18 @@ float injectRWFault(FiState *fiState, float tau_c, float omega, float p1, float 
 	float tau_hat_c, tau_hat_f;
 	if (primaryRWActive && fiState->cmdToFaultRW) {
 		if (omega < delta_omega && omega > -delta_omega) {
-		  // If the reaction wheel speed is close to 0, then we actually want to just 
-		  // turn off the commanded torque. The inclusion of friction could force the
-		  // augmented friction to spin the wheel past 0 and in the opposite direction,
-		  // which is impossible for natural friction to do.
-		  tau_hat_c = 0.05*tau_c;  
+			// If the reaction wheel speed is close to 0, then we actually want to just 
+			// turn off the commanded torque. The inclusion of friction could force the
+			// augmented friction to spin the wheel past 0 and in the opposite direction,
+			// which is impossible for natural friction to do.
+			tau_hat_f = calcInducedFriction(omega, p1, p2); 
+			if (tau_c < tau_hat_f && tau_c > 0) {
+				return 0;
+			}
+			if (tau_c > tau_hat_f && tau_c < 0) {
+				return 0;
+			}
+			return tau_hat_c - tau_hat_f;
 		} else {
 			tau_hat_f = calcInducedFriction(omega, p1, p2); 
 			// The commanded torque should be decreased by the 'induced' friction, which

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -156,14 +156,14 @@ void loop()
 
   if (blocks) {
     // uncomment out these lines to inject a rw fault. DO NOT DELETE UNTIL GSU IS INTEGRATED
-    if (millis() > 40000 && !fiState->cmdToFaultRW) {
-      Serial.println("faulting");
-      fiState->cmdToFaultRW = 1;
-    }
-    if (millis() > 100000 && fiState->cmdToFaultRW) {
-      Serial.println("Unfaulting");
-      fiState->cmdToFaultRW = 0;
-    }
+    //if (millis() > 40000 && !fiState->cmdToFaultRW) {
+    //  Serial.println("faulting");
+    //  fiState->cmdToFaultRW = 1;
+    //}
+    //if (millis() > 100000 && fiState->cmdToFaultRW) {
+    //  Serial.println("Unfaulting");
+    //  fiState->cmdToFaultRW = 0;
+    //}
 
     deltaThetaRadFine1 = ((pixy.blocks[0].x)*convertPixToDegFine - centerOffsetDegFine)*convertDegToRad;
     fsInjection(&deltaThetaRadFine1, fiState);

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -107,7 +107,7 @@ float rwSpeedRad;
 float const p1 = 0.0000335653965; // mNm/(rad/s), viscous friction 
 float const p2 = 0.1303; // mNm, coloumb friction
 float MOI = 1; //MOI of RW, stubbed out for now
-float delta_omega = 50; // small delta near zero where we set torque to zero to simulate friction. TODO: Tune this value
+float delta_omega = 15; // small delta near zero where we set torque to zero to simulate friction. TODO: Tune this value
 uint16_t const lengthOfHistory = 1000;
 // currentIndex points to the most recent data point. The last 100 data points are accumulated "behind"
 // this index. For example, if the currentIndex is 55, the order (in terms of recency) of the stored indicies
@@ -156,14 +156,14 @@ void loop()
 
   if (blocks) {
     // uncomment out these lines to inject a rw fault. DO NOT DELETE UNTIL GSU IS INTEGRATED
-    // if (millis() > 30000 && !fiState->cmdToFaultRW && millis() < 60000) {
-    //   Serial.println("faulting");
-    //   fiState->cmdToFaultRW = 1;
-    // }
-    // if (millis() > 600000 && fiState->cmdToFaultRW) {
-    //   Serial.println("Unfaulting");
-    //   fiState->cmdToFaultRW = 0;
-    // }
+    if (millis() > 40000 && !fiState->cmdToFaultRW) {
+      Serial.println("faulting");
+      fiState->cmdToFaultRW = 1;
+    }
+    if (millis() > 100000 && fiState->cmdToFaultRW) {
+      Serial.println("Unfaulting");
+      fiState->cmdToFaultRW = 0;
+    }
 
     deltaThetaRadFine1 = ((pixy.blocks[0].x)*convertPixToDegFine - centerOffsetDegFine)*convertDegToRad;
     fsInjection(&deltaThetaRadFine1, fiState);


### PR DESCRIPTION
Added logic to reaction wheel injection for the near-zero-wheel-speed induced friction state (i.e. when we want to be careful that our induced torque doesn't spin the wheel past zero in the opposite direction, since friction can't actually do that)

Now, if the magnitude of the commanded torque is greater than what is induced, then we take the difference and apply it to the motor. If it is not greater, then we simply set the commanded torque to 0 and let the rw come to rest.

This has been tested and verified on the mocksat both in the nominal case and the injected case