### PR TITLE
Pixy and motor switching

### DIFF
--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -211,14 +211,14 @@ void loop()
     pwm_duty3 = (uint32_t) pwm_duty2;
 
     // Testing switching b/w rw
-    if (millis() < 20000){
+    //if (millis() < 20000){
       pwm.pinDuty( 6, pwm_duty3 );  // computed duty cycle on Pin 6 (Primary RW)
       pwm.pinDuty( 7, pwm_duty_inactive );  // inactive duty cycle (127 PWM) on Pin 7 (Secondary RW)
-    }
-    else{
-      pwm.pinDuty( 6, pwm_duty_inactive );  // inactive duty cycle (127 PWM) on Pin 6 (Primary RW)
-      pwm.pinDuty( 7, pwm_duty3 );  // computed duty cycle on Pin 7 (Secondary RW)
-    }
+    //}
+    //else{
+    //  pwm.pinDuty( 6, pwm_duty_inactive );  // inactive duty cycle (127 PWM) on Pin 6 (Primary RW)
+    //  pwm.pinDuty( 7, pwm_duty3 );  // computed duty cycle on Pin 7 (Secondary RW)
+    //}
     
     storeTorqueAndIncrementIndex(commandedTorqueHistory, &currentIndex, commandedTorque_mNm, lengthOfHistory);
   }else if(coarseBlocks){
@@ -247,14 +247,14 @@ void loop()
     pwm_duty3 = (uint32_t) pwm_duty2;
 
     // Testing switching b/w rw
-    if (millis() < 20000){
+    //if (millis() < 20000){
       pwm.pinDuty( 6, pwm_duty3 );  // computed duty cycle on Pin 6 (Primary RW)
       pwm.pinDuty( 7, pwm_duty_inactive );  // inactive duty cycle (127 PWM) on Pin 7 (Secondary RW)
-    }
-    else{
-      pwm.pinDuty( 6, pwm_duty_inactive );  // inactive duty cycle (127 PWM) on Pin 6 (Primary RW)
-      pwm.pinDuty( 7, pwm_duty3 );  // computed duty cycle on Pin 7 (Secondary RW)
-    }
+    //}
+    //else{
+    //  pwm.pinDuty( 6, pwm_duty_inactive );  // inactive duty cycle (127 PWM) on Pin 6 (Primary RW)
+    // pwm.pinDuty( 7, pwm_duty3 );  // computed duty cycle on Pin 7 (Secondary RW)
+    //}
 
     storeTorqueAndIncrementIndex(commandedTorqueHistory, &currentIndex, commandedTorque_mNm, lengthOfHistory);
   }else {

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -22,7 +22,7 @@ Servo myservo;
 
 DuePWM pwm( PWM_FREQ1, PWM_FREQ2 );
 
-PixySPI_SS finePixy1(PRIMARY_FS_PIN);
+//PixySPI_SS finePixy1(PRIMARY_FS_PIN);
 PixySPI_SS finePixy2(SECONDARY_FS_PIN);
 PixySPI_SS coarsePixy(CS_PIN);
 
@@ -47,7 +47,7 @@ void setup()
 { 
   Serial.begin(9600);
   Serial.print("Starting...\n");
-  finePixy1.init();
+  //finePixy1.init();
   finePixy2.init();
   coarsePixy.init();
   Setpoint = 0;
@@ -100,7 +100,7 @@ double duty_to_bin = 256.0/100.0;
 double pwm_duty;
 double pwmOffset = 50;
 double pwm_duty2;
-uint32_t pwm_duty3;
+uint32_t pwm_duty3 = 127;
 uint32_t pwm_duty_inactive = 127;
 static int i = 0;
 int k;
@@ -176,14 +176,14 @@ void loop()
   if (fineBlocks) {
   
     // uncomment out these lines to inject a rw fault. DO NOT DELETE UNTIL GSU IS INTEGRATED
-    //if (millis() > 40000 && !fiState->cmdToFaultRW) {
-    //  Serial.println("faulting");
-    //  fiState->cmdToFaultRW = 1;
-    //}
-    //if (millis() > 100000 && fiState->cmdToFaultRW) {
-    //  Serial.println("Unfaulting");
-    //  fiState->cmdToFaultRW = 0;
-    //}
+    if (millis() > 40000 && !fiState->cmdToFaultRW) {
+      Serial.println("faulting");
+      fiState->cmdToFaultRW = 1;
+    }
+    if (millis() > 100000 && fiState->cmdToFaultRW) {
+      Serial.println("Unfaulting");
+      fiState->cmdToFaultRW = 0;
+    }
 
     deltaThetaRadFine2 = ((finePixy2.blocks[0].x)*convertPixToDegFine - centerOffsetDegFine)*convertDegToRad;
     fsInjection(&deltaThetaRadFine2, fiState);
@@ -264,5 +264,5 @@ void loop()
     pwm.pinDuty( 6, pwm_duty_inactive );
     pwm.pinDuty( 7, pwm_duty_inactive );
   }
-  Serial.println(pwm_duty3);
+  //Serial.println(pwm_duty3);
 }


### PR DESCRIPTION
coarse and fine sensor switch responsibility as expected on mocksat. Can switch between motor controllers but code is commented out and left there for reference. Using PixySPI_SS for switching and leave both motor controller enabled and switch using pwm signals.