### PR TITLE
Fm master  integrate slew

### DIFF
--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -42,7 +42,10 @@ double deltaThetaRadCoarse;
 double Setpoint, deltaThetaRad, commandedTorque_mNm;
 
 //Specify the links and initial tuning parameters
-double const Kp=6.31600775000411, Ki=0.200331632823233, Kd=36.7969404030176, N=0.5;
+//double const Kp=6.31600775000411, Ki=0.200331632823233, Kd=36.7969404030176, N=0.5;
+// THESE ARE PRETTY GOOT
+//double const Kp=9.31600775000411, Ki=0.800331632823233, Kd=46.7969404030176, N=0.5;
+double const Kp=12.31600775000411, Ki=0.800331632823233, Kd=46.7969404030176, N=0.5;
 PID myPID(&deltaThetaRad, &commandedTorque_mNm, &Setpoint, Kp, Ki, Kd, N, DIRECT);
 
 //Allocate for fm/fi state variables

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -108,6 +108,7 @@ double pwmOffset = 50;
 double pwm_duty2;
 uint32_t pwm_duty3 = 127;
 uint32_t pwm_duty_inactive = 127;
+uint32_t pwm_duty_slew = 140;
 static int i = 0;
 int k;
 char buf[32];
@@ -201,10 +202,18 @@ void loop() {
     Serial.println("using coarse blocks because no fine 1 or 2");
     deltaThetaRad = deltaThetaRadCoarse;
     runFmAndControl();
-  } else {
+  } else if (millis() > 5000) {
     // If we do not pick up blocks set PWM to 50% to shut off motors
-    pwm.pinDuty(PRIMARY_MOTOR_PIN, pwm_duty_inactive);
-    pwm.pinDuty(REDUNDANT_MOTOR_PIN, pwm_duty_inactive);
+    Serial.println("Not in view anymore");
+    Serial.println(deltaThetaRadCoarse);
+    pwm_duty_slew = deltaThetaRadCoarse < 0 ? 107 : 147;
+    if (fmState->activeRW == 1) {
+      pwm.pinDuty(PRIMARY_MOTOR_PIN, pwm_duty_slew);
+      pwm.pinDuty(REDUNDANT_MOTOR_PIN, pwm_duty_inactive);
+    } else {
+      pwm.pinDuty(PRIMARY_MOTOR_PIN, pwm_duty_inactive);
+      pwm.pinDuty(REDUNDANT_MOTOR_PIN, pwm_duty_slew);
+    }
   }
 }
 

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -44,8 +44,7 @@ double Setpoint, deltaThetaRad, commandedTorque_mNm;
 //Specify the links and initial tuning parameters
 //double const Kp=6.31600775000411, Ki=0.200331632823233, Kd=36.7969404030176, N=0.5;
 // THESE ARE PRETTY GOOT
-//double const Kp=9.31600775000411, Ki=0.800331632823233, Kd=46.7969404030176, N=0.5;
-double const Kp=12.31600775000411, Ki=0.800331632823233, Kd=46.7969404030176, N=0.5;
+double const Kp=9.31600775000411, Ki=0.800331632823233, Kd=46.7969404030176, N=0.5;
 PID myPID(&deltaThetaRad, &commandedTorque_mNm, &Setpoint, Kp, Ki, Kd, N, DIRECT);
 
 //Allocate for fm/fi state variables


### PR DESCRIPTION
FI/FM on mocksat in 90% working state.

This also gets slew working. When not in view, we will slew back in the direction we most recently went away from. (i.e. if the target moved out from the mockSat's left, the mockSat will attempt to bring it in to view by spinning to it's left.

Only thing not working is fault detection of reaction wheel fault. We cannot achieve this with current methods due to noise in reaction wheel speed data. 

We're currently exploring other methods for fault detection, but we may be too close to symposium to implement them in time. These methods are:
* Attaching an IMU in an effort to get better mocksat torque response data and using this to compare with the commanded torques.
* Using the pixy data to do a two degree numerical differentiation to calculate the angular acceleration of the mocksat, and then compare vs the commanded torques.
Both of these methods are also susceptible to innaccuracies in the MOI of the mockSat, since they will require that instead of the MOI of the reaction wheels.

For Symposium, we have fs injection working on a timer, and automatically recover once a fault is detected by the fm system. We have rw injection working, causing off-nominal performance. We do a timed recovery by switching to the redundant rw after 20s. To inject either of these faults, uncomment `injectTimedRwFault` or `injectTimeFSFault` in the main loop.

Also adds some 'ad hoc' gains which seemed to better track the target