### PR TITLE
Fi rw with slew

### DIFF
--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -198,7 +198,7 @@ void loop() {
     deltaThetaRad = fmState->activeFS == 1 ? deltaThetaRadFine1 : deltaThetaRadFine2;
 
     // uncomment out these lines to inject a fs or rw fault. DO NOT DELETE UNTIL GSU IS INTEGRATED
-    injectTimedRWFault();
+    //injectTimedRWFault();
     //injectTimedFSFault();
     storeSensorData(fineDeltaTheta, coarseDeltaTheta, sensorStackPtr, deltaThetaRad, deltaThetaRadCoarse);
     getOrderedHistory(fineDeltaTheta, orderedFineDeltaTheta, sensorDataLength, sensorStackPtr);

--- a/main_Script/main_Script.ino
+++ b/main_Script/main_Script.ino
@@ -216,7 +216,7 @@ void loop() {
     runControl();
   } else if (millis() > 5000) {
     // If we do not pick up blocks set PWM to 50% to shut off motors
-    commandedTorqueSlew = deltaThetaRadCoarse < 0 ? -10.85 : 10.85;
+    commandedTorqueSlew = deltaThetaRadCoarse < 0 ? -2 : 2;
     commandedTorqueSlew = injectRWFault(fiState, commandedTorqueSlew, rwSpeedRad, p1, p2, delta_omega, 
     fmState->activeRW == 1);
     pwm_duty_slew = (commandedTorque_mNm*mNm_to_mA*mA_to_duty + pwmOffset)*duty_to_bin;


### PR DESCRIPTION
Gets injection into rw working with "slew" case. The "slew" case is the case where no pixy's detect an object, and we send a constant torque command until we pick up the object again.

Slew works as expected in nominal operation, and exhibits significantly diminished performance exemplary of increased rw friction in the injected case.